### PR TITLE
Replace "tuner$tune" with "tuner$optimize"

### DIFF
--- a/mlr3tuning/mlr3tuningcheatsheet.tex
+++ b/mlr3tuning/mlr3tuningcheatsheet.tex
@@ -187,7 +187,7 @@
 									instance = TuningInstance\$new(\\
 									\hspace*{1ex} task, learner, resampling, measures, tune\_ps, evals20)\\
 									tuner = tnr("random\_search")\\
-									tuner\$tune(instance)\\
+									tuner\$optimize(instance)\\
 									instance\$result}
 							\end{codeboxexample}
 						\end{myblock}


### PR DESCRIPTION
Addresses #5 and makes the cheatsheet match mlr3tuning and mlr3book contents. I kind of hesitate to submit this as v0.2 of mlr3tuning is not yet in CRAN.