### PR TITLE
Fix typos

### DIFF
--- a/mlr3/mlr3.Rmd
+++ b/mlr3/mlr3.Rmd
@@ -394,7 +394,7 @@ bmr1 = bmr
 ```
 
 ```{r, results='hide'}
-bmr$combine(bmr)
+bmr$combine(bmr1)
 c(bmr, bmr1) # alternative S3 method
 ```
 Merge other `BenchmarkResult`.

--- a/mlr3tuning/mlr3tuning.Rmd
+++ b/mlr3tuning/mlr3tuning.Rmd
@@ -36,7 +36,7 @@ Scalar doubles, integers, factors or logicals are combined to define a multivari
 ss = ps(
   <id> = p_int(lower, upper),
   <id> = p_dbl(lower, upper),
-  <id> = p_dct(levels),
+  <id> = p_fct(levels),
   <id> = p_lgl())
 ```
 


### PR DESCRIPTION
Fixing small typos in the base mlr3 and the hyperparameter tuning cheatsheet.